### PR TITLE
Fix bug in error-object-polyfill for npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/Cimpress-MCP/microservice-utilities.js#readme",
   "dependencies": {
     "axios": "^0.17.1",
-    "error-object-polyfill": "^1.0.11",
+    "error-object-polyfill": "^1.0.13",
     "json-stringify-safe": "^5.0.1",
     "jsonwebtoken": "^8.1.0",
     "jwk-to-pem": "^1.2.6",


### PR DESCRIPTION
See this thing, which makes no sense in the `error-object-polyfill`:
https://github.com/wparad/error-object-polyfill.js/commit/f3ec501e01c8d54c43991ea1dd1c76c861ba9897