### PR TITLE
Handling when no kid got specified

### DIFF
--- a/src/authorizer.js
+++ b/src/authorizer.js
@@ -49,6 +49,11 @@ class Authorizer {
 
     let kid = unverifiedToken && unverifiedToken.header && unverifiedToken.header.kid;
 
+    if (!kid) {
+      this.logFunction({ level: 'ERROR', title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token });
+      throw new Error('Unauthorized');
+    }
+
     let key = null;
     try {
       key = await this.getPublicKeyPromise(kid);

--- a/src/authorizer.js
+++ b/src/authorizer.js
@@ -50,7 +50,7 @@ class Authorizer {
     let kid = unverifiedToken && unverifiedToken.header && unverifiedToken.header.kid;
 
     if (!kid) {
-      this.logFunction({ level: 'ERROR', title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token });
+      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token });
       throw new Error('Unauthorized');
     }
 

--- a/test/authorizer.test.js
+++ b/test/authorizer.test.js
@@ -66,6 +66,18 @@ describe('authorizer.js', function() {
         expectedResult: null
       },
       {
+        name: 'no kid specified',
+        request: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn },
+        errorLog: { level: errorlevel, title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token },
+        token,
+        unverifiedToken: { header: { kid: null } },
+        publicKeyError,
+        publicKeyId,
+        publicKey: 'unit-test-public-key',
+        expectedErrorResult: 'Unauthorized',
+        expectedResult: null
+      },
+      {
         name: 'fails to get public key',
         request: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn },
         errorLog: { level: errorlevel, title: 'Unauthorized', details: 'Failed to get public key', method: methodArn, error: publicKeyError },

--- a/test/authorizer.test.js
+++ b/test/authorizer.test.js
@@ -68,7 +68,7 @@ describe('authorizer.js', function() {
       {
         name: 'no kid specified',
         request: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn },
-        errorLog: { level: errorlevel, title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token },
+        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token },
         token,
         unverifiedToken: { header: { kid: null } },
         publicKeyError,


### PR DESCRIPTION
If no KID got specified, we currently don't know the underlying reason; whether it was a follow-up error, or the actual token was wrong.