### PR TITLE
Allow specifying static data

### DIFF
--- a/src/requestLogger.js
+++ b/src/requestLogger.js
@@ -9,13 +9,15 @@ class RequestLogger {
    * @param {Boolean}  configuration.extendErrorObjects extends Error object globally in order to provide proper JSON
    *                   representation of Error objects.
    * @param {Number}   configuration.jsonSpace the number of spaces that are used then stringifying the message.
+   * @param {Object}   configuration.staticData Any static data that are assigned to every log message. Typical might be an environment parameter or version number.
    */
-  constructor(configuration = { logFunction: console.log, extendErrorObjects: true, jsonSpace: 2 }) {
+  constructor(configuration = { logFunction: console.log, extendErrorObjects: true, jsonSpace: 2, staticData: undefined }) {
     this.logFunction = configuration.logFunction;
     this.jsonSpace = configuration.jsonSpace === null || configuration.jsonSpace === undefined ? 2 : configuration.jsonSpace;
     if (configuration.extendErrorObjects) {
       require('error-object-polyfill');
     }
+    this.staticData = configuration.staticData;
 
     this.invocationId = null;
   }
@@ -25,6 +27,14 @@ class RequestLogger {
    */
   startInvocation() {
     this.invocationId = uuid.v4();
+  }
+
+  /**
+   * Allows to set the static data. It will override static data specified with the configuration at construction time.
+   * @param {Object} staticData Any static data that are assigned to every log message. Typical might be an environment parameter or version number.
+   */
+  setStaticData(staticData) {
+    this.staticData = staticData;
   }
 
   log(message) {
@@ -40,6 +50,11 @@ class RequestLogger {
     } else if (type === 'object' && Object.keys(message).length === 0) {
       console.error('Empty message object.');
       return;
+    }
+
+    if (this.staticData && typeof this.staticData === 'object') {
+      let baseObject = Object.assign({}, this.staticData);
+      messageAsObject = Object.assign(baseObject, messageAsObject);
     }
 
     let payload = {

--- a/src/requestLogger.js
+++ b/src/requestLogger.js
@@ -9,32 +9,24 @@ class RequestLogger {
    * @param {Boolean}  configuration.extendErrorObjects extends Error object globally in order to provide proper JSON
    *                   representation of Error objects.
    * @param {Number}   configuration.jsonSpace the number of spaces that are used then stringifying the message.
-   * @param {Object}   configuration.staticData Any static data that are assigned to every log message. Typical might be an environment parameter or version number.
    */
-  constructor(configuration = { logFunction: console.log, extendErrorObjects: true, jsonSpace: 2, staticData: undefined }) {
+  constructor(configuration = { logFunction: console.log, extendErrorObjects: true, jsonSpace: 2 }) {
     this.logFunction = configuration.logFunction;
     this.jsonSpace = configuration.jsonSpace === null || configuration.jsonSpace === undefined ? 2 : configuration.jsonSpace;
     if (configuration.extendErrorObjects) {
       require('error-object-polyfill');
     }
-    this.staticData = configuration.staticData;
 
     this.invocationId = null;
   }
 
   /**
    * Create a new invocation which will end up setting the additional invocation metadata for the request, which will be used when logging.
-   */
-  startInvocation() {
-    this.invocationId = uuid.v4();
-  }
-
-  /**
-   * Allows to set the static data. It will override static data specified with the configuration at construction time.
    * @param {Object} staticData Any static data that are assigned to every log message. Typical might be an environment parameter or version number.
    */
-  setStaticData(staticData) {
+  startInvocation(staticData) {
     this.staticData = staticData;
+    this.invocationId = uuid.v4();
   }
 
   log(message) {
@@ -53,8 +45,7 @@ class RequestLogger {
     }
 
     if (this.staticData && typeof this.staticData === 'object') {
-      let baseObject = Object.assign({}, this.staticData);
-      messageAsObject = Object.assign(baseObject, messageAsObject);
+      messageAsObject = Object.assign({}, this.staticData, messageAsObject);
     }
 
     let payload = {

--- a/test/requestLogger.test.js
+++ b/test/requestLogger.test.js
@@ -126,8 +126,9 @@ describe('RequestLogger', () => {
         expectedMessage: {
           title: 'Payload too large',
           fields: ['invocationId', 'message'],
-          truncatedPayload: `{\n  "invocationId": null,\n  "message": {\n    "title": "Platform Request Error",\n    "exception": {\n      "message": "${[...Array(9883)].map(() => 1).join('')}`
-        }
+          truncatedPayload: `{\n  "invocationId": "{{invocationId}}",\n  "message": {\n    "title": "Platform Request Error",\n    "exception": {\n      "message": "${[...Array(9849)].map(() => 1).join('')}`
+        },
+        resetInvocationId: true
       },
       {
         name: 'errors are serialized correctly',
@@ -178,14 +179,19 @@ describe('RequestLogger', () => {
     testCases.map(testCase => {
       it(testCase.name, () => {
         let jsonSpace = testCase.jsonSpace === undefined ? 2 : testCase.jsonSpace;
-        let logObj = { invocationId: null, message: testCase.expectedMessage };
-        let expectedLogString = JSON.stringify(logObj, null, jsonSpace);
-
+        
         let logger = { log() { } };
         let loggerMock = sandbox.mock(logger);
-        loggerMock.expects('log').withExactArgs(expectedLogString);
+        let logFunc = msg => logger.log(msg);
 
-        let requestLogger = new RequestLogger({ logFunction: logger.log, extendErrorObjects: true, jsonSpace, staticData: testCase.staticData });
+        let requestLogger = new RequestLogger({ logFunction: logFunc, extendErrorObjects: true, jsonSpace });
+        requestLogger.startInvocation(testCase.staticData);
+        
+        let logObj = { invocationId: requestLogger.invocationId, message: testCase.expectedMessage };
+        let expectedLogString = JSON.stringify(logObj, null, jsonSpace);
+        expectedLogString = expectedLogString.replace(/{{invocationId}}/, requestLogger.invocationId);
+        loggerMock.expects('log').withExactArgs(expectedLogString);
+        
         requestLogger.log(testCase.message);
 
         loggerMock.verify();

--- a/test/requestLogger.test.js
+++ b/test/requestLogger.test.js
@@ -142,6 +142,37 @@ describe('RequestLogger', () => {
             message: expectedErrorMessage
           }
         }
+      },
+      {
+        name: 'allows to specify static data',
+        staticData: {
+          environment: 'test',
+          someValue: 'unit-test'
+        },
+        message: {
+          title: 'some message'
+        },
+        expectedMessage: {
+          environment: 'test',
+          someValue: 'unit-test',
+          title: 'some message'
+        }
+      },
+      {
+        name: 'allows to specify static data, and does not override existing value',
+        staticData: {
+          environment: 'test',
+          someValue: 'static-value'
+        },
+        message: {
+          someValue: 'dynamic-value',
+          title: 'some message'
+        },
+        expectedMessage: {
+          environment: 'test',
+          someValue: 'dynamic-value',
+          title: 'some message'
+        }
       }
     ];
     testCases.map(testCase => {
@@ -154,7 +185,7 @@ describe('RequestLogger', () => {
         let loggerMock = sandbox.mock(logger);
         loggerMock.expects('log').withExactArgs(expectedLogString);
 
-        let requestLogger = new RequestLogger({ logFunction: logger.log, extendErrorObjects: true, jsonSpace });
+        let requestLogger = new RequestLogger({ logFunction: logger.log, extendErrorObjects: true, jsonSpace, staticData: testCase.staticData });
         requestLogger.log(testCase.message);
 
         loggerMock.verify();


### PR DESCRIPTION
It can be useful to allow specifying static data that are logged with each request, such as an environment or lambda version etc.