### PR TITLE
Log token when unverified

### DIFF
--- a/src/authorizer.js
+++ b/src/authorizer.js
@@ -100,7 +100,7 @@ class Authorizer {
 
     let unverifiedToken = jwtManager.decode(token, { complete: true });
     if (!unverifiedToken) {
-      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Invalid token', method: methodArn });
+      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Invalid token', method: methodArn, token });
       throw new Error('Unauthorized');
     }
 

--- a/src/authorizer.js
+++ b/src/authorizer.js
@@ -115,7 +115,7 @@ class Authorizer {
     try {
       identity = await jwtManager.verify(token, key, { algorithms: ['RS256'] });
     } catch (exception) {
-      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Error verifying token', error: exception, method: methodArn });
+      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Error verifying token', error: exception, method: methodArn, token });
       throw new Error('Unauthorized');
     }
 

--- a/test/authorizer.test.js
+++ b/test/authorizer.test.js
@@ -59,7 +59,7 @@ describe('authorizer.js', function() {
       {
         name: 'fails when invalid token specified',
         request: { headers: { authorization: `Bearer ${token}` }, methodArn },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Invalid token', method: methodArn },
+        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Invalid token', method: methodArn, token },
         token,
         unverifiedToken: null,
         expectedErrorResult: 'Unauthorized',

--- a/test/authorizer.test.js
+++ b/test/authorizer.test.js
@@ -80,7 +80,7 @@ describe('authorizer.js', function() {
       {
         name: 'fails when jwt verification fails',
         request: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Error verifying token', method: methodArn, error: jwtVerifyError },
+        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Error verifying token', method: methodArn, error: jwtVerifyError, token },
         token,
         unverifiedToken: { header: { kid: publicKeyId } },
         jwtVerifyError,


### PR DESCRIPTION
When trying to help clients why their token was unverified, it's useful to have the token available in the log message (same as for the other conditions above).