### PR TITLE
Allow verification of audience and other JWT properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ const configuration = {
   // URL to get jwk keys to verify token
   jwkKeyListUrl: 'https://example.com/.well-known/jwks.json',
   // custom resolver that returns additional context form the AWS Lambda authorizer
-  authorizerContextResolver: () => ({
+  authorizerContextResolver: (identity, token) => ({
     authorizerContextResult: 'my context'
   }),
-  // optional usage plan that's being created
+  // optional AWS API Gateway usage plan
+  // See details at https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html
   usagePlan: 'usage-plan-id',
   // jwtVerifyOptions that are passed into jsonwebtoken
   // see https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback

--- a/README.md
+++ b/README.md
@@ -39,7 +39,20 @@ npm install openapi-factory
 ```javascript
 const Api = require('openapi-factory');
 const { Authorizer, RequestLogger } = require('microservice-utilities');
-const configuration = { jwkKeyListUrl: 'https://example.com/.well-known/jwks.json' };
+const configuration = {
+  // URL to get jwk keys to verify token
+  jwkKeyListUrl: 'https://example.com/.well-known/jwks.json',
+  // custom resolver that returns additional context form the AWS Lambda authorizer
+  authorizerContextResolver: () => ({
+    authorizerContextResult: 'my context'
+  }),
+  // optional usage plan that's being created
+  usagePlan: 'usage-plan-id',
+  // jwtVerifyOptions that are passed into jsonwebtoken
+  // see https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback
+  // defaults to { algorithms: ['RS256'] }
+  jwtVerifyOptions: { algorithms: ['RS256'], audience: 'my-audience' }
+};
 
 let requestLogger = new RequestLogger();
 let authorizer = new Authorizer(msg => requestLogger.log(msg), configuration);


### PR DESCRIPTION
Allowing to pass in options that are passed further to the JWT token verifier.

I went with a straight-forward pass-through instead of having clients pass in a subset of those properties like audience and algorithm. This couples it to a given implementation of the JWT token verifier, on the other hand gives the full power to the users of this library. I'm happy to pivot to a different direction.