### PR TITLE
Add a function to send a delete request with a body

### DIFF
--- a/src/platformClient.js
+++ b/src/platformClient.js
@@ -132,6 +132,7 @@ class PlatformClient {
 
   /**
    * Delete the resource on the given url. Bearer token is automatically injected if tokenResolverFunction was provided to the constructor.
+   * @see {@link deleteWithBody} if you need a body in your delete call.
    * @param {String} url to send the request to
    * @param {Object} headers request headers
    * @return {Promise<Object>}
@@ -139,6 +140,20 @@ class PlatformClient {
   async delete(url, headers) {
     return this.client.delete(url, {
       headers: await this.createHeadersWithResolvedToken(headers)
+    });
+  }
+
+  /**
+   * Delete the resource on the given url. Bearer token is automatically injected if tokenResolverFunction was provided to the constructor.
+   * @param {String} url to send the request to
+   * @param {String} data to send in the request body
+   * @param {Object} headers request headers
+   * @return {Promise<Object>}
+   */
+  async deleteWithBody(url, data, headers) {
+    return this.client.delete(url, {
+      headers: await this.createHeadersWithResolvedToken(headers),
+      data
     });
   }
 

--- a/test/platformClient.test.js
+++ b/test/platformClient.test.js
@@ -142,6 +142,31 @@ describe('PlatformClient', () => {
     });
   });
 
+  describe('deleteWithBody()', () => {
+    it('injects the resolved token into Authorization header', async () => {
+      const testUrl = 'unit-test-url';
+      const testData = 'unit-test-data';
+      const testToken = 'unit-test-token';
+      const testHeaders = { UnitTestHeader: 'unit-test-header-value' };
+      const expectedHeaders = { UnitTestHeader: 'unit-test-header-value', Authorization: `Bearer ${testToken}` };
+
+      let tokenResolverFunctionMock = sandbox.stub();
+      tokenResolverFunctionMock.resolves(testToken);
+
+      let httpClient = { delete() {} };
+      let httpClientMock = sandbox.mock(httpClient);
+      httpClientMock.expects('delete').withExactArgs(testUrl, { headers: expectedHeaders, data: testData }).resolves();
+
+      let platformClient = new PlatformClient(null, tokenResolverFunctionMock);
+      platformClient.client = httpClient;
+
+      await platformClient.deleteWithBody(testUrl, testData, testHeaders);
+
+      expect(tokenResolverFunctionMock.calledOnce).to.equal(true);
+      httpClientMock.verify();
+    });
+  });
+
   describe('head()', () => {
     it('injects the resolved token into Authorization header', async () => {
       const testUrl = 'unit-test-url';


### PR DESCRIPTION
I added a separate function named `deleteWithBody` to avoid function signature inconsistency or breaking changes.