### PR TITLE
Check whether keys exist in the result to avoid a 500

### DIFF
--- a/src/authorizer.js
+++ b/src/authorizer.js
@@ -35,7 +35,7 @@ class Authorizer {
       throw new Error('InternalServerError');
     }
 
-    let jwk = result.data.keys.find(key => key.kid === kid);
+    let jwk = result.data.keys && result.data.keys.find(key => key.kid === kid);
     if (jwk) {
       return jwkConverter(jwk);
     }


### PR DESCRIPTION
This happened last night when Auth0 had a partial outage.