### PR TITLE
Add path to Unauthorized log

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jwk-to-pem": "^1.2.6",
     "uuid": "^3.2.1"
   },
-  "peerDependencies":{
+  "peerDependencies": {
     "aws-sdk": "^2.0.0"
   },
   "devDependencies": {

--- a/src/authorizer.js
+++ b/src/authorizer.js
@@ -92,24 +92,22 @@ class Authorizer {
   }
 
   async getPolicy(request) {
-    this.logFunction({ level: 'INFO', title: 'Authorizer.getPolicy()', data: request });
     let methodArn = request.methodArn;
-    let path = request.path;
     let token = this.getTokenFromAuthorizationHeader(request);
     if (!token) {
-      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'No token specified', method: methodArn, path });
+      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'No token specified', method: methodArn, data: request });
       throw new Error('Unauthorized');
     }
 
     let unverifiedToken = jwtManager.decode(token, { complete: true });
     if (!unverifiedToken) {
-      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Invalid token', method: methodArn, token, path });
+      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Invalid token', method: methodArn, token, data: request });
       throw new Error('Unauthorized');
     }
 
     let kid = unverifiedToken && unverifiedToken.header && unverifiedToken.header.kid;
     if (!kid) {
-      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token, path });
+      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token, data: request });
       throw new Error('Unauthorized');
     }
 
@@ -118,9 +116,11 @@ class Authorizer {
     try {
       identity = await jwtManager.verify(token, key, this.jwtVerifyOptions);
     } catch (exception) {
-      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Error verifying token', error: exception, method: methodArn, token, path });
+      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Error verifying token', error: exception, method: methodArn, token, data: request });
       throw new Error('Unauthorized');
     }
+
+    this.logFunction({ level: 'INFO', title: 'Verified Token', data: request });
 
     let resolver = this.configuration.authorizerContextResolver || (() => ({ jwt: token }));
     const policy = {

--- a/src/authorizer.js
+++ b/src/authorizer.js
@@ -94,21 +94,22 @@ class Authorizer {
   async getPolicy(request) {
     this.logFunction({ level: 'INFO', title: 'Authorizer.getPolicy()', data: request });
     let methodArn = request.methodArn;
+    let path = request.path;
     let token = this.getTokenFromAuthorizationHeader(request);
     if (!token) {
-      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'No token specified', method: methodArn });
+      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'No token specified', method: methodArn, path });
       throw new Error('Unauthorized');
     }
 
     let unverifiedToken = jwtManager.decode(token, { complete: true });
     if (!unverifiedToken) {
-      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Invalid token', method: methodArn, token });
+      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Invalid token', method: methodArn, token, path });
       throw new Error('Unauthorized');
     }
 
     let kid = unverifiedToken && unverifiedToken.header && unverifiedToken.header.kid;
     if (!kid) {
-      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token });
+      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token, path });
       throw new Error('Unauthorized');
     }
 
@@ -117,7 +118,7 @@ class Authorizer {
     try {
       identity = await jwtManager.verify(token, key, this.jwtVerifyOptions);
     } catch (exception) {
-      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Error verifying token', error: exception, method: methodArn, token });
+      this.logFunction({ level: 'WARN', title: 'Unauthorized', details: 'Error verifying token', error: exception, method: methodArn, token, path });
       throw new Error('Unauthorized');
     }
 

--- a/test/authorizer.test.js
+++ b/test/authorizer.test.js
@@ -26,40 +26,41 @@ describe('authorizer.js', function() {
     let jwtVerifyError = new Error('unit-test-error while verifying JWT');
     let publicKeyId = 'unit-test-kid';
     let warnlevel = 'WARN';
+    let path = 'unit-test-path';
 
     let testCases = [
       {
         name: 'fails when header not available in request',
-        request: { methodArn },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn },
+        request: { methodArn, path },
+        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, path },
         expectedErrorResult: 'Unauthorized',
         expectedResult: null
       },
       {
         name: 'fails when no authorization header available',
-        request: { headers: {}, methodArn },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn },
+        request: { headers: {}, methodArn, path },
+        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, path },
         expectedErrorResult: 'Unauthorized',
         expectedResult: null
       },
       {
         name: 'fails when invalid authorization header specified (single word)',
-        request: { headers: { authorization: 'only-single-word' }, methodArn },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn },
+        request: { headers: { authorization: 'only-single-word' }, methodArn, path },
+        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, path },
         expectedErrorResult: 'Unauthorized',
         expectedResult: null
       },
       {
         name: 'fails when invalid authorization header specified (more than two words)',
-        request: { headers: { authorization: 'more than two words' }, methodArn },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn },
+        request: { headers: { authorization: 'more than two words' }, methodArn, path },
+        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, path },
         expectedErrorResult: 'Unauthorized',
         expectedResult: null
       },
       {
         name: 'fails when invalid token specified',
-        request: { headers: { authorization: `Bearer ${token}` }, methodArn },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Invalid token', method: methodArn, token },
+        request: { headers: { authorization: `Bearer ${token}` }, methodArn, path },
+        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Invalid token', method: methodArn, token, path },
         token,
         unverifiedToken: null,
         expectedErrorResult: 'Unauthorized',
@@ -67,8 +68,8 @@ describe('authorizer.js', function() {
       },
       {
         name: 'no kid specified',
-        request: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token },
+        request: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn, path },
+        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token, path },
         token,
         unverifiedToken: { header: { kid: null } },
         publicKeyError,
@@ -79,8 +80,8 @@ describe('authorizer.js', function() {
       },
       {
         name: 'fails when jwt verification fails',
-        request: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Error verifying token', method: methodArn, error: jwtVerifyError, token },
+        request: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn, path },
+        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Error verifying token', method: methodArn, error: jwtVerifyError, token, path },
         token,
         unverifiedToken: { header: { kid: publicKeyId } },
         jwtVerifyError,

--- a/test/authorizer.test.js
+++ b/test/authorizer.test.js
@@ -32,35 +32,35 @@ describe('authorizer.js', function() {
       {
         name: 'fails when header not available in request',
         request: { methodArn, path },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, path },
+        expectedLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, data: { methodArn, path } },
         expectedErrorResult: 'Unauthorized',
         expectedResult: null
       },
       {
         name: 'fails when no authorization header available',
         request: { headers: {}, methodArn, path },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, path },
+        expectedLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, data: { headers: {}, methodArn, path } },
         expectedErrorResult: 'Unauthorized',
         expectedResult: null
       },
       {
         name: 'fails when invalid authorization header specified (single word)',
         request: { headers: { authorization: 'only-single-word' }, methodArn, path },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, path },
+        expectedLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, data: { headers: { authorization: 'only-single-word' }, methodArn, path } },
         expectedErrorResult: 'Unauthorized',
         expectedResult: null
       },
       {
         name: 'fails when invalid authorization header specified (more than two words)',
         request: { headers: { authorization: 'more than two words' }, methodArn, path },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, path },
+        expectedLog: { level: warnlevel, title: 'Unauthorized', details: 'No token specified', method: methodArn, data: { headers: { authorization: 'more than two words' }, methodArn, path } },
         expectedErrorResult: 'Unauthorized',
         expectedResult: null
       },
       {
         name: 'fails when invalid token specified',
         request: { headers: { authorization: `Bearer ${token}` }, methodArn, path },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Invalid token', method: methodArn, token, path },
+        expectedLog: { level: warnlevel, title: 'Unauthorized', details: 'Invalid token', method: methodArn, token, data:{ headers: { authorization: `Bearer ${token}` }, methodArn, path } },
         token,
         unverifiedToken: null,
         expectedErrorResult: 'Unauthorized',
@@ -69,7 +69,7 @@ describe('authorizer.js', function() {
       {
         name: 'no kid specified',
         request: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn, path },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token, path },
+        expectedLog: { level: warnlevel, title: 'Unauthorized', details: 'Token did no provide a KID', method: methodArn, token, data: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn, path } },
         token,
         unverifiedToken: { header: { kid: null } },
         publicKeyError,
@@ -81,7 +81,7 @@ describe('authorizer.js', function() {
       {
         name: 'fails when jwt verification fails',
         request: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn, path },
-        errorLog: { level: warnlevel, title: 'Unauthorized', details: 'Error verifying token', method: methodArn, error: jwtVerifyError, token, path },
+        expectedLog: { level: warnlevel, title: 'Unauthorized', details: 'Error verifying token', method: methodArn, error: jwtVerifyError, token, data: { headers: { authorization: `Bearer ${token}`, kid: publicKeyId }, methodArn, path } },
         token,
         unverifiedToken: { header: { kid: publicKeyId } },
         jwtVerifyError,
@@ -93,6 +93,7 @@ describe('authorizer.js', function() {
       {
         name: 'resolves principal',
         request: { headers: { authorization: `Bearer ${token}` }, methodArn },
+        expectedLog: { level: 'INFO', title: 'Verified Token', data: { headers: { authorization: `Bearer ${token}` }, methodArn } },
         token,
         unverifiedToken: { header: { kid: publicKeyId } },
         publicKeyId,
@@ -123,6 +124,7 @@ describe('authorizer.js', function() {
       {
         name: 'resolves principal with custom JwtVerifyOptions',
         request: { headers: { authorization: `Bearer ${token}` }, methodArn },
+        expectedLog: { level: 'INFO', title: 'Verified Token', data: { headers: { authorization: `Bearer ${token}` }, methodArn } },
         token,
         unverifiedToken: { header: { kid: publicKeyId } },
         publicKeyId,
@@ -157,6 +159,7 @@ describe('authorizer.js', function() {
       {
         name: 'resolves principal with client token',
         request: { headers: { authorization: `Bearer ${token}` }, methodArn },
+        expectedLog: { level: 'INFO', title: 'Verified Token', data: { headers: { authorization: `Bearer ${token}` }, methodArn } },
         token,
         unverifiedToken: { header: { kid: publicKeyId } },
         publicKeyId,
@@ -187,6 +190,7 @@ describe('authorizer.js', function() {
       {
         name: 'use custom context resolver',
         request: { headers: { authorization: `Bearer ${token}` }, methodArn },
+        expectedLog: { level: 'INFO', title: 'Verified Token', data: { headers: { authorization: `Bearer ${token}` }, methodArn } },
         token,
         unverifiedToken: { header: { kid: publicKeyId } },
         publicKeyId,
@@ -225,10 +229,8 @@ describe('authorizer.js', function() {
       it(testCase.name, async () => {
         let logger = { log() { } };
         let loggerMock = sandbox.mock(logger);
-        let requestLog = { level: 'INFO', title: 'Authorizer.getPolicy()', data: testCase.request };
-        loggerMock.expects('log').withExactArgs(requestLog).once();
-        if (testCase.errorLog) {
-          loggerMock.expects('log').withExactArgs(testCase.errorLog).once();
+        if (testCase.expectedLog) {
+          loggerMock.expects('log').withExactArgs(testCase.expectedLog).once();
         }
 
         let authorizer = new Authorizer(logger.log, testCase.configuration || testConfiguration);


### PR DESCRIPTION
Adding path to log message. This is primarily because requests from an ALB do not have the methodArn property, but both API Gateway and ALBs add the path paramenter. 